### PR TITLE
Chore/telnet

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ server.use(bodyParser());
 router.post('/', ctx => {
   ctx.body = ctx.request.body;
   console.log(ctx.body)
-  memcached.add('foo', 'bar', 10);
+  memcached.add('foo', 'bar', 10, (err) => {} );
   memcached.get('foo', (err, data) => { console.log(data) });
 });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,7 @@ services:
       - test.env
   
   memcached:
-    image: memcached:alpine
+    image: memcached
+  
+  telnet:
+    image: mikesplain/telnet


### PR DESCRIPTION
@laurxnemeth I think this all worked except the `memcached.add` function needed a callback to work. Try:

```
docker-compose up dev
docker-compose run telnet memcached 11211
curl -X POST localhost:3003/
```

Meanwhile back on the telnet container try:

```
get foo
```

I was getting the correct `bar` value.